### PR TITLE
Make top-level commands work with CLI version 5.0.0.

### DIFF
--- a/vboxmanage_completion.bash
+++ b/vboxmanage_completion.bash
@@ -117,12 +117,7 @@ _vboxmanage() {
 
 
 _vboxmanage_realopts() {
-    echo $( \
-	vboxmanage | grep -i vboxmanage| \
-	cut -d' ' -f2 | \
-	grep '\[' | \
-	tr -s '[\[\]\|]' ' ' \
-    ) 
+    echo $(vboxmanage | grep -Eo "^\s{2}[a-z]+")
     echo " "
 }
 


### PR DESCRIPTION
Modify `grep` call to match top-level commands as returned by "Oracle VM VirtualBox Command Line Management Interface Version 5.0.0".
